### PR TITLE
[24/01/24] jaeeunKim / 1문제

### DIFF
--- a/0x0C/jaeeunKim/BOJ_16987_answer.cpp
+++ b/0x0C/jaeeunKim/BOJ_16987_answer.cpp
@@ -1,0 +1,53 @@
+#include <bits/stdc++.h>
+using namespace std;
+/*
+    BOJ 16987 계란으로 계란치기
+    https://www.acmicpc.net/problem/16987
+
+*/
+int n;
+int s[10], w[10]; // pair를 굳이 안써도 됨!
+int mx = 0;
+int cnt = 0; // 깨진 계란의 수
+
+void solve(int a){ // a번째 계란으로 다른 걸 깰 차례다
+    if(a == n){  // 제일 오른쪽의 계란을 기준으로 치는 경우까지 도달했다면
+        mx = max(mx, cnt); // 현재
+        return;
+    }
+
+    //현재 a번째 계란이 깨져있거나, a계란 빼고 다 깨졌다면?
+    if(s[a] <= 0 || cnt == n-1){ 
+        solve(a+1); // a+1번째 계란으로 다른 걸 깨부수기
+        return;
+    }
+    for(int t =0; t < n; t++){ // t번째 계란과 뿌셔보자
+        // t가 a이거나, t번째 계란이 깨진 경우는 pass
+        if(t == a or s[t] <= 0) continue;
+
+        // a번째 계란과 t번째 계란을 부딪혀
+        s[a] -= w[t];
+        s[t] -= w[a];
+
+        // 깨진 계란 count
+        if(s[a] <= 0) cnt++;
+        if(s[t] <= 0) cnt++;
+        
+        solve(a+1); // 하나를 쳤으니, 문제의 3의 조건으로 한칸 오른쪽의 계란으로 다른걸 깰 차례!
+
+        // 원상 복귀시키기
+        if(s[a] <= 0) cnt--;
+        if(s[t] <= 0) cnt--;
+        s[a] += w[t];
+        s[t] += w[a];
+    }
+}
+
+int main(){
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+    for(int i = 0; i< n; i++)
+        cin >> s[i] >> w[i];
+    solve(0);
+    cout <<mx;
+}


### PR DESCRIPTION
## BOJ_16987 계란으로 계란치기
`백트래킹` / [문제 링크](https://www.acmicpc.net/problem/16987)
```
1. 가장 왼쪽의 계란을 든다.
2. 손에 들고 있는 계란으로 깨지지 않은 다른 계란 중에서 하나를 친다. 단, 손에 든 계란이 깨졌거나 깨지지 않은 다른 계란이 없으면 치지 않고 넘어간다. 이후 손에 든 계란을 원래 자리에 내려놓고 3번 과정을 진행한다.
3. 가장 최근에 든 계란의 한 칸 오른쪽 계란을 손에 들고 2번 과정을 다시 진행한다. 단, 가장 최근에 든 계란이 가장 오른쪽에 위치한 계란일 경우 계란을 치는 과정을 종료한다.
```


**단계적으로 생각하자**... 는 무슨 단계적으로 생각해도 모르겠다. 
그리고 문제 설명에서 쓸데없는 설명은 좀 없었으면 좋겠네 ㅎㅎ 
+) 테스트 케이스 이해 못해서 문제 이해하는데 시간 다 씀. ㅉㅉ 수듄


### 입력 데이터 타입의 전환
`pair<int,int> eggs[9]` $\rightarrow$ `int s[10], w[10]; `
계란의 내구성과 무게를 `pair`로 묶어서 굳이 사용하지 말고, 각각 배열로 처리해서 index로 접근해버리는 것이 코드 상 더 편함

### 백트래킹의 의미
```C++
s[a] -= w[t];
s[t] -= w[a];
if(s[a] <= 0) cnt++;
if(s[t] <= 0) cnt++;

solve(a+1);

if(s[a] <= 0) cnt--;
if(s[t] <= 0) cnt--;
s[a] += w[t];
s[t] += w[a];
```
정답 코드를 보니까, 백트래킹의 의미를 이제서야 알겠다. 
가지를 뻗었다가 돌아오면 원래 상태로 만들어줘야(**Back** 해야) 한다.

### 흐름
0️⃣  조건1: 가장 왼쪽의 계란을 든다.
`solve(int a)` 
</br>
1️⃣  **백트래킹**
* `a`와 `b`를 깬 경우, 바로 `solve(a+1)` 호출 (하나 깨면 내려놓고,  `a` 오른쪽에 있는 걸 기준으로 깨야 하기 때문, 문제의 2번 조건 참고)
* 그리고 트리의 끝까지 탐색을 하고 돌아 오면 b 다음 계란과 `a`를 깨야 하기 때문에 `a`와 `b`를 깬 값을 원상 복귀 시켜줌

</br>

2️⃣  조건3: 단, 가장 최근에 든 계란이 가장 오른쪽에 위치한 계란일 경우 계란을 치는 과정을 종료한다.
```C++
if(a == n){
    mx = max(mx, cnt); 
    return;
}
```
* 만약 `a`가 `n`이라면 제일 오른쪽까지 다 부딪혀본 경우다, 즉 완전 탐색 완료의 경우
* 이런 경우는 지금 경우의 수에서 갱신된 깨진 계란의 수(`cnt`)와 `mx` 간의 최대값을 갱신시켜 준다. (모든 경우의 수에서 가장 많이 깬 계란의 수를 구해야 하니까)

</br>

3️⃣  조건 2: 단, 손에 든 계란이 깨졌거나 깨지지 않은 다른 계란이 없으면 치지 않고 넘어간다. 이후 손에 든 계란을 원래 자리에 내려놓고 3번 과정을 진행한다.
```C++
if(s[a] <= 0 || cnt == n-1){ 
    solve(a+1); // a+1번째 계란으로 다른 걸 깨부수기
    return;
}
```
* 문제 조건 2에서 만약 기준으로 하는 계란이 깨졌거나 기준 계란 외 나머지 계란이 다 깨졌다면 깨지 않고 3으로 패스